### PR TITLE
Added wrapper for DeviceType enum

### DIFF
--- a/src/source/device/DeviceRegistry.cpp
+++ b/src/source/device/DeviceRegistry.cpp
@@ -13,15 +13,15 @@ namespace itk {
         _registeredDevices = {
                 DeviceFactory::createDevice("Test device 01", "Description of the test device", DeviceType::AUDIO),
                 DeviceFactory::createDevice("Test device 02", "Description of the test device", DeviceType::AUDIO),
-                DeviceFactory::createDevice("Test device 03", "Description of the test device", DeviceType::AUDIO),
+                DeviceFactory::createDevice("Test device 03", "Description of the test device", DeviceType::CONTROL),
                 DeviceFactory::createDevice("Test device 04", "Description of the test device", DeviceType::AUDIO),
                 DeviceFactory::createDevice("Test device 05", "Description of the test device", DeviceType::AUDIO),
                 DeviceFactory::createDevice("Test device 06", "Description of the test device", DeviceType::AUDIO),
                 DeviceFactory::createDevice("Test device 07", "Description of the test device", DeviceType::AUDIO),
-                DeviceFactory::createDevice("Test device 08", "Description of the test device", DeviceType::AUDIO),
+                DeviceFactory::createDevice("Test device 08", "Description of the test device", DeviceType::CONTROL),
                 DeviceFactory::createDevice("Test device 09", "Description of the test device", DeviceType::AUDIO),
                 DeviceFactory::createDevice("Test device 10", "Description of the test device", DeviceType::AUDIO),
-                DeviceFactory::createDevice("Test device 11", "Description of the test device", DeviceType::AUDIO),
+                DeviceFactory::createDevice("Test device 11", "Description of the test device", DeviceType::CONTROL),
                 DeviceFactory::createDevice("Test device 12", "Description of the test device", DeviceType::AUDIO),
         };
     }

--- a/src/wrapper/itk.cpp
+++ b/src/wrapper/itk.cpp
@@ -16,10 +16,12 @@ namespace boost {
 BOOST_PYTHON_MODULE(itk)
 {
     using boost::python::class_;
+    using boost::python::enum_;
     using boost::python::no_init;
     using boost::noncopyable;
     using boost::python::vector_indexing_suite;
     using itk::Device;
+    using itk::DeviceType;
     using itk::wrapper::PyDeviceRegistry;
 
     class_<Device, Device::Ptr, noncopyable>("Device", no_init)
@@ -29,6 +31,10 @@ BOOST_PYTHON_MODULE(itk)
 
     class_<PyDeviceRegistry>("DeviceRegistry")
             .def("registeredDevices", &PyDeviceRegistry::registeredDevices);
+
+    enum_<DeviceType>("DeviceType")
+            .value("Audio", DeviceType::AUDIO)
+            .value("Control", DeviceType::CONTROL);
 }
 
 #endif //INSTRUMENT_TOOL_KIT_ITK_H


### PR DESCRIPTION
Device Type wrapper was added and the Device Type can now be used in python.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/frank-krick/itk/1)

<!-- Reviewable:end -->
